### PR TITLE
Fixing dependency issue with latest react native

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
     "author": "Jonathan Wynne",
-    "dependencies": {
-        "react-native": "^0.13.2"
-    },
     "description": "react native wrapper around ios app review library",
     "devDependencies": {
         "react-native": "^0.13.0"


### PR DESCRIPTION
in later versions of react native, adding react-native as a dependency causes naming collisions

```
Failed to build DependencyGraph: @providesModule naming collision:
  Duplicate module name: UniversalWorkerNodeHandle
```
