### PR TITLE
Update build tools version to 23.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 android {
   compileSdkVersion 23
-  buildToolsVersion '23.0.3'
+  buildToolsVersion '23.0.1'
   defaultConfig {
     minSdkVersion 16
     targetSdkVersion 22


### PR DESCRIPTION
Fixes #11 that causes an error for those who only have 23.0.1 version of Build Tools installed. 

Since that is the version used by React Native it makes sense to use that and prevent people from running into this issue.